### PR TITLE
Fix deprecation warnings for string bounds calculation

### DIFF
--- a/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
+++ b/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
@@ -281,14 +281,27 @@ static char UIScrollViewPullToRefreshView;
         self.subtitleLabel.text = subtitle.length > 0 ? subtitle : nil;
         
         
-        CGSize titleSize = [self.titleLabel.text sizeWithFont:self.titleLabel.font
-                                            constrainedToSize:CGSizeMake(labelMaxWidth,self.titleLabel.font.lineHeight)
-                                                lineBreakMode:self.titleLabel.lineBreakMode];
+        NSMutableParagraphStyle *titleStyle = [NSMutableParagraphStyle new];
+        titleStyle.lineBreakMode = self.titleLabel.lineBreakMode;
         
+        CGRect titleRect = [self.titleLabel.text boundingRectWithSize:CGSizeMake(labelMaxWidth, self.titleLabel.font.lineHeight)
+                                                              options:NSStringDrawingUsesLineFragmentOrigin
+                                                           attributes:@{
+                                                                        NSFontAttributeName: self.titleLabel.font,
+                                                                        NSParagraphStyleAttributeName: titleStyle
+                                                                        } context:NULL];
+        CGSize titleSize = titleRect.size;
         
-        CGSize subtitleSize = [self.subtitleLabel.text sizeWithFont:self.subtitleLabel.font
-                                                  constrainedToSize:CGSizeMake(labelMaxWidth,self.subtitleLabel.font.lineHeight)
-                                                      lineBreakMode:self.subtitleLabel.lineBreakMode];
+        NSMutableParagraphStyle *subtitleStyle = [NSMutableParagraphStyle new];
+        subtitleStyle.lineBreakMode = self.subtitleLabel.lineBreakMode;
+        
+        CGRect subtitleRect = [self.subtitleLabel.text boundingRectWithSize:CGSizeMake(labelMaxWidth, self.subtitleLabel.font.lineHeight)
+                                                                    options:NSStringDrawingUsesLineFragmentOrigin
+                                                                 attributes:@{
+                                                                              NSFontAttributeName: self.subtitleLabel.font,
+                                                                              NSParagraphStyleAttributeName: subtitleStyle
+                                                                              } context:NULL];
+        CGSize subtitleSize = subtitleRect.size;
         
         CGFloat maxLabelWidth = MAX(titleSize.width,subtitleSize.width);
         


### PR DESCRIPTION
Switched to `boundingRectWithSize` in accordance with the iOS 7 deprecation warning.